### PR TITLE
Update RNShadowListener.kt

### DIFF
--- a/android/src/main/java/com/curvedbottomnavigationbar/RNShadow/RNShadowListener.kt
+++ b/android/src/main/java/com/curvedbottomnavigationbar/RNShadow/RNShadowListener.kt
@@ -70,7 +70,7 @@ class RNShadowListener(private val reactContext: ReactContext) : EventDispatcher
   }
 
   init {
-    eventDispatcher = reactContext.getNativeModule(UIManagerModule::class.java).eventDispatcher
-    eventDispatcher.addListener(this)
+    eventDispatcher = reactContext.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
+    eventDispatcher?.addListener(this)
   }
 }


### PR DESCRIPTION
fixes `Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type UIManagerModule` on android and RN 0.64